### PR TITLE
Revert "chore(deps): update docker.io/linuxserver/bazarr docker tag to v1.4.0"

### DIFF
--- a/k8s/apps/multimedia/bazarr/deployment.k8s.yaml
+++ b/k8s/apps/multimedia/bazarr/deployment.k8s.yaml
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: bazarr
-          image: docker.io/linuxserver/bazarr:1.4.0
+          image: docker.io/linuxserver/bazarr:1.3.1
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
v1.4.0 breaks postgresql connection