### PR TITLE
Revert "chore(deps): update helm release cilium to v1.16.3"

### DIFF
--- a/infra/talos/cni/kustomization.yaml
+++ b/infra/talos/cni/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.16.3
+    version: 1.16.2
     releaseName: cilium
     namespace: cilium
     valuesFile: values.yaml

--- a/k8s/apps/network/cilium/helmrelease.k8s.yaml
+++ b/k8s/apps/network/cilium/helmrelease.k8s.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.16.3
+      version: 1.16.2
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
Reverts eaglesemanation/ops.emnt.dev#615

```
Failed to pull image "quay.io/cilium/cilium:v1.16.3@sha256:62d2a09bbef840a46099ac4c69421c90f84f28d018d479749049011329aa7f28": rpc error: 
code = NotFound 
desc = failed to pull and unpack image "quay.io/cilium/cilium@sha256:62d2a09bbef840a46099ac4c69421c90f84f28d018d479749049011329aa7f28": 
	failed to extract layer sha256:4e39e89e9b0dd4b199feb09be62fd76407e95e5b934a2914f8e7296596444b66: 
	failed to get reader from content store: blob sha256:1a993bf5d4621042b9685b73dfcd1530ff0156e2f8da772f39babd214100c2de expected at /var/lib/containerd/io.containerd.content.v1.content/blobs/sha256/1a993bf5d4621042b9685b73dfcd1530ff0156e2f8da772f39babd214100c2de: 
	blob not found: not found
```