### PR TITLE
Revert "chore(deps): update helm release authentik to v2024.10.0"

### DIFF
--- a/k8s/apps/security/authentik/helmrelease.k8s.yaml
+++ b/k8s/apps/security/authentik/helmrelease.k8s.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: 2024.10.0
+      version: 2024.8.3
       sourceRef:
         kind: HelmRepository
         name: goauthentik


### PR DESCRIPTION
Reverts eaglesemanation/ops.emnt.dev#640 due to https://github.com/goauthentik/authentik/issues/11912